### PR TITLE
Updated iconv-lite to version 0.4.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cheerio": "0.19.0",
     "es6-set": "0.1.1",
     "highlight.js": "8.8.0",
-    "iconv-lite": "0.4.12",
+    "iconv-lite": "0.4.13",
     "lodash": "3.10.1",
     "minimist": "1.2.0",
     "rc": "1.1.2",


### PR DESCRIPTION
:rocket:

iconv-lite just published version 0.4.13, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 3 commits (ahead by 3, behind by 0).
- [f5ec51b](https://github.com/ashtuchkin/iconv-lite/commit/f5ec51b1e7dd1477a3570824960641eebdc5fbc6): Release 0.4.13: Fix deprecation notice
- [5ff2c26](https://github.com/ashtuchkin/iconv-lite/commit/5ff2c2655911061f9958ad049d54f301e81a7fa7): Merge pull request #108 from dbkaplun/console-warning
- [aaa55aa](https://github.com/ashtuchkin/iconv-lite/commit/aaa55aaf651888a7efda7dbdbdf4dbc9e8a2966a): Fix console.warning -> console.error

See the [full diff](https://github.com/ashtuchkin/iconv-lite/compare/5f5f71492e287c9c7231009103ddf9e8884df62d...f5ec51b1e7dd1477a3570824960641eebdc5fbc6).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
