### PR TITLE
Updated es6-set to version 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "blessed": "0.1.81",
     "bluebird": "2.10.2",
     "cheerio": "0.19.0",
-    "es6-set": "0.1.1",
+    "es6-set": "0.1.2",
     "highlight.js": "8.8.0",
     "iconv-lite": "0.4.13",
     "lodash": "3.10.1",


### PR DESCRIPTION
:rocket:

es6-set just published version 0.1.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 15 commits (ahead by 15, behind by 0).
- [b33f141](https://github.com/medikoo/es6-set/commit/b33f141e9087d3b287bc50a0bf6eaf43a5141634): v0.1.2
- [29b387f](https://github.com/medikoo/es6-set/commit/29b387fa39dd375da323620a22fe7777277cc97d): Update Travis CI configuration
- [e6aef3d](https://github.com/medikoo/es6-set/commit/e6aef3dcbaeaaf3eba5b4b2b2d6a415dabd83a53): Update Travis CI configuration
- [5be4cce](https://github.com/medikoo/es6-set/commit/5be4cce12fee750cdc2cb993edfe308fa1a8d7a8): -- whitespace
- [66006f8](https://github.com/medikoo/es6-set/commit/66006f84d4372f2c56d7ba74ee6dfc8f3cea7cd1): Update lint configuration
- [2ef913b](https://github.com/medikoo/es6-set/commit/2ef913b1df9265f459ea79926659957a49c0f927): Set#filter extension
- [6bb7329](https://github.com/medikoo/es6-set/commit/6bb7329a9837c0fafa113b63a70c5ecbceceda94): Remove leftovers after logic cleanup
- [896da71](https://github.com/medikoo/es6-set/commit/896da71fd34b90600b97c2b0c8cff4b96d765434): Rename LICENCE to LICENSE
- [f7d720e](https://github.com/medikoo/es6-set/commit/f7d720e7b1c1d3aca29ddd7beababb4631508fb2): Fix initialization
- [fa8dc87](https://github.com/medikoo/es6-set/commit/fa8dc87801c542d57f5064df4a8e564dae7fd944): -- whitespace
- [b739f19](https://github.com/medikoo/es6-set/commit/b739f1975687e8fe98a5f92253678a7112a50ebe): In case of native Set, assure proper extension
- [603a928](https://github.com/medikoo/es6-set/commit/603a928f3979ae11561df7f987f508a1a5124733): Remove invalid class extension test
- [46201d7](https://github.com/medikoo/es6-set/commit/46201d76adec04649c93389a1efc25426ba2dccd): Remove invalid constructor test
- [90759a9](https://github.com/medikoo/es6-set/commit/90759a91648ce74eb81c30f3e6c12c28f2e390eb): Pass only extendable implementation of sets
- [ac5c217](https://github.com/medikoo/es6-set/commit/ac5c217b2e93b9db8491b61852adbc1a755de7b0): Restrict native Set validation

See the [full diff](https://github.com/medikoo/es6-set/compare/769f7391b194b25900a79d132d21f4abefb14201...b33f141e9087d3b287bc50a0bf6eaf43a5141634).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
