### PR TITLE
fix(node4): temporarily pin text-buffer to slap-editor/text-buffer#06fa9ed

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "semver": "5.0.3",
     "slap-util": "1.0.5",
     "tape": "4.2.1",
-    "text-buffer": "7.1.2"
+    "text-buffer": "slap-editor/text-buffer#06fa9ed"
   },
   "devDependencies": {
     "get-random-port": "0.0.1"


### PR DESCRIPTION
problem is text-buffer > serializable > get-parameter-names@1.x > goatslacker/testla#4
