### PR TITLE
Update text-buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "semver": "5.0.3",
     "slap-util": "1.0.5",
     "tape": "4.2.1",
-    "text-buffer": "slap-editor/text-buffer#06fa9ed"
+    "text-buffer": "7.1.3"
   },
   "devDependencies": {
     "get-random-port": "0.0.1"


### PR DESCRIPTION
7.1.3 has fixed the `npm install` issue with testla.
