### PR TITLE
chore: roll back to cheerio@0.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "base-widget": "1.0.10",
     "blessed": "0.1.81",
     "bluebird": "3.3.4",
-    "cheerio": "0.21.0",
+    "cheerio": "^0.20.0",
     "copy-paste": "^1.1.4",
     "es6-set": "0.1.4",
     "highlight.js": "9.1.0",


### PR DESCRIPTION
-  cheerio version 0.21 has been pulled from npm
-  see cheeriojs/cheerio#872 for reference
