### PR TITLE
feat: add editor option for initial content

### DIFF
--- a/lib/Editor.js
+++ b/lib/Editor.js
@@ -48,8 +48,14 @@ function Editor (opts) {
     bottom: 0
   }, self.options.buffer));
 
-  self.textBuf = new TextBuffer({encoding: self.options.defaultEncoding});
-  self.textBuf.loadSync();
+  self.textBuf = new TextBuffer({
+    encoding: self.options.defaultEncoding,
+    text: self.options.text
+  });
+
+  if (!self.options.text) {
+    self.textBuf.loadSync();
+  }
 
   self.selection = self.textBuf.markPosition(new Point(0, 0), {type: 'selection', invalidate: 'never'});
   self.scroll = new Point(0, 0);
@@ -607,7 +613,7 @@ Editor.prototype._initHandlers = function () {
                 str = ch + self.textBuf.getTextInRange(selectionRange) + str;
                 selection.setRange(self.textBuf.setTextInRange(selectionRange, str));
               }
-              else  
+              else
                 selection.setRange(self.textBuf.setTextInRange(selectionRange, ch));
               selection.reversed = false;
               selection.clearTail();


### PR DESCRIPTION
-  add options.text for initial content of Editor
-  do not overwrite via .loadSync if options.text is present
-  see [marionebl/git-editor/src/components/area](https://github.com/marionebl/git-editor/blob/bc923870b4c9d8a4d572b505deefd2a65b9238b8/src/components/area/index.js) for use case
