### PR TITLE
Update debug -> inspect

### DIFF
--- a/lib/highlight/client.js
+++ b/lib/highlight/client.js
@@ -6,10 +6,10 @@ var Promise = require('bluebird');
 var init = Promise.resolve();
 var opts = minimist(process.execArgv);
 var forkOpts = {silent: false};
-if (['debug', 'debug-brk'].some(function (opt) { return opt in opts; })) {
+if (['inspect', 'inspect-brk'].some(function (opt) { return opt in opts; })) {
   init = init
     .then(require('get-random-port'))
-    .then(function (port) { forkOpts.execArgv = ['--debug=' + port]; })
+    .then(function (port) { forkOpts.execArgv = ['--inspect=' + port]; })
     .return(null);
 }
 


### PR DESCRIPTION
Current node versions don't accept `--debug` and `--debug-brk` anymore without complaints, and current version debuggers pass `--inspect` and `--inspect-brk` anyway. The change solves the problem reported in #242, but I have not tested the functionality that was presumably intended by the original author.